### PR TITLE
#14 케이스 상호 이슈 fix

### DIFF
--- a/lib/credit_card_sms_parser.rb
+++ b/lib/credit_card_sms_parser.rb
@@ -31,10 +31,10 @@ class KoreanCreditCardLexer < RLTK::Lexer
   rule(/^잔액/) { :type }
   rule(/주식회사\p{Hangul}+/) {|t| [:shop_name, t[4..-1]]}
   rule(/^[\p{Hangul},\u3000]+( +[\p{Hangul},\u3000]+)*?$/) { |t|
+    t.gsub!(/\u3000/,' ')
     t.chomp!(' 사용')
     t.chomp!(' 일시불')
     t.chomp!(' 취소')
-    t.gsub!(/\u3000/,' ')
     [:shop_name, t.strip]
   }
   rule(/[0-9A-Za-z\p{Hangul}]+/) {|t| [:shop_name, t.strip]}

--- a/lib/credit_card_sms_parser.rb
+++ b/lib/credit_card_sms_parser.rb
@@ -30,10 +30,11 @@ class KoreanCreditCardLexer < RLTK::Lexer
   rule(/일시불/) { :type }
   rule(/^잔액/) { :type }
   rule(/주식회사\p{Hangul}+/) {|t| [:shop_name, t[4..-1]]}
-  rule(/^\p{Hangul}+( +\p{Hangul}+)*?$/) { |t|
+  rule(/^[\p{Hangul},\u3000]+( +[\p{Hangul},\u3000]+)*?$/) { |t|
     t.chomp!(' 사용')
     t.chomp!(' 일시불')
     t.chomp!(' 취소')
+    t.gsub!(/\u3000/,' ')
     [:shop_name, t.strip]
   }
   rule(/[0-9A-Za-z\p{Hangul}]+/) {|t| [:shop_name, t.strip]}


### PR DESCRIPTION
해당 이슈같은 경우, ideographic space(\u3000)를 shop_name에 포함된 공백과 같이 간주해서 처리할 필요가 있다고 생각되어 line 33의 lexer rule을 수정했습니다.

같은 shop_name이지만 line 32, 39는 white space / ideographic space의 해당 문제와 무관하다고 판단하여 수정하지 않았습니다.

parse_sms 메소드 레벨에서 sms_message에 \u3000을 white space와 gsub하는 방법도 있다고 생각되지만, Readme의 프로젝트 기여 가이드라인 내에서 수정하는 방향으로 pull request를 작성했습니다.

감사합니다.
